### PR TITLE
Adds Zauber Cauldron Creation Animation

### DIFF
--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/create.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/create.mcfunction
@@ -2,12 +2,12 @@
 # at cauldron position
 # ran from playe/submain
 
-#summon marker AEC
+# summon marker AEC
 summon area_effect_cloud ~ ~ ~ {Radius:0,Age:-2147483648,CustomName:'"gm4_zauber_cauldron"',Tags:["gm4_zauber_cauldron"],Particle:"block air"}
 advancement grant @s only gm4:zauber_cauldrons_create
 playsound minecraft:entity.illusioner.prepare_mirror master @a[distance=..8] ~ ~ ~ 1 1.6
 
-#start creation animation
+# start creation animation
 summon area_effect_cloud ~ ~ ~ {Radius:0,Age:-40,CustomName:'"gm4_zc_creation_animation"',Tags:["gm4_zc_creation_animation"],Particle:"block air"}
 scoreboard players set creation_counter gm4_zc_data 1
 schedule function gm4_zauber_cauldrons:cauldron/create_animation 1t

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/create.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/create.mcfunction
@@ -2,6 +2,12 @@
 # at cauldron position
 # ran from playe/submain
 
-# position checks
+#summon marker AEC
 summon area_effect_cloud ~ ~ ~ {Radius:0,Age:-2147483648,CustomName:'"gm4_zauber_cauldron"',Tags:["gm4_zauber_cauldron"],Particle:"block air"}
 advancement grant @s only gm4:zauber_cauldrons_create
+playsound minecraft:entity.illusioner.prepare_mirror master @a[distance=..8] ~ ~ ~ 1 1.6
+
+#start creation animation
+summon area_effect_cloud ~ ~ ~ {Radius:0,Age:-40,CustomName:'"gm4_zc_creation_animation"',Tags:["gm4_zc_creation_animation"],Particle:"block air"}
+scoreboard players set creation_counter gm4_zc_data 1
+schedule function gm4_zauber_cauldrons:cauldron/create_animation 1t

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/create_animation.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/create_animation.mcfunction
@@ -1,0 +1,8 @@
+# @s = server
+# scheduled from gm4_zauber_cauldron:cauldron/create
+
+execute if score creation_counter gm4_zc_data matches ..40 run schedule function gm4_zauber_cauldrons:cauldron/create_animation 1t
+scoreboard players add creation_counter gm4_zc_data 1
+
+execute as @e[type=area_effect_cloud,tag=gm4_zc_creation_animation] at @s run teleport @s ^0.15 ^ ^0.025 facing entity @e[type=area_effect_cloud,tag=gm4_zauber_cauldron,distance=..1,limit=1]
+execute at @e[type=area_effect_cloud,tag=gm4_zc_creation_animation] run particle minecraft:enchant ~ ~0.6 ~ 0 0 0 0.001 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/extra_items/create_possessed_items.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/extra_items/create_possessed_items.mcfunction
@@ -2,7 +2,7 @@
 # run from use_extra_items AND release_from_bottle
 # at @s
 
-# summons 1 vex for every unused item entity in a cauldron or every vex in bottle (on recipe processing)
-summon vex ~ ~1.5 ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Possessed Item",{"translate":"entity.gm4.possessed_item"}]}',CustomNameVisible:0,LifeTicks:320,Attributes:[{Name:generic.attackDamage,Base:2}],Health:4.0,Motion:[0.0,0.25,0.0],ActiveEffects:[{Id:11,Amplifier:10,Duration:20,ShowParticles:0b}]}
+#summons 1 vex for every unused item entity in a cauldron or every vex in bottle (on recipe processing)
+summon vex ~ ~ ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Possessed Item",{"translate":"entity.gm4.possessed_item"}]}',CustomNameVisible:0,LifeTicks:320,Attributes:[{Name:generic.attackDamage,Base:2}],Health:4.0,Motion:[0.0,0.25,0.0],ActiveEffects:[{Id:11,Amplifier:10,Duration:20,ShowParticles:0b}]}
 scoreboard players remove @s gm4_zc_fullness 1
 execute if score @s gm4_zc_fullness matches 1.. run function gm4_zauber_cauldrons:cauldron/extra_items/create_possessed_items

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/extra_items/create_possessed_items.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/cauldron/extra_items/create_possessed_items.mcfunction
@@ -2,7 +2,7 @@
 # run from use_extra_items AND release_from_bottle
 # at @s
 
-#summons 1 vex for every unused item entity in a cauldron or every vex in bottle (on recipe processing)
+# summons 1 vex for every unused item entity in a cauldron or every vex in bottle (on recipe processing)
 summon vex ~ ~ ~ {CustomName:'{"translate":"%1$s%3427655$s","with":["Possessed Item",{"translate":"entity.gm4.possessed_item"}]}',CustomNameVisible:0,LifeTicks:320,Attributes:[{Name:generic.attackDamage,Base:2}],Health:4.0,Motion:[0.0,0.25,0.0],ActiveEffects:[{Id:11,Amplifier:10,Duration:20,ShowParticles:0b}]}
 scoreboard players remove @s gm4_zc_fullness 1
 execute if score @s gm4_zc_fullness matches 1.. run function gm4_zauber_cauldrons:cauldron/extra_items/create_possessed_items

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/init.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/init.mcfunction
@@ -16,6 +16,8 @@ function gm4_zauber_cauldrons:recipes/flowers/initiate_flower_types
 function gm4_zauber_cauldrons:recipes/chorus/initiate_chorus_amounts
 scoreboard players set modulo gm4_zc_fullness 3
 
+#1.16 Reminder Note : Setup yellow shulker box and forceloaded chunk
+
 execute unless score zauber_cauldrons gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Zauber Cauldrons"}
 scoreboard players set zauber_cauldrons gm4_modules 1
 

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/init.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/init.mcfunction
@@ -16,7 +16,7 @@ function gm4_zauber_cauldrons:recipes/flowers/initiate_flower_types
 function gm4_zauber_cauldrons:recipes/chorus/initiate_chorus_amounts
 scoreboard players set modulo gm4_zc_fullness 3
 
-#1.16 Reminder Note : Setup yellow shulker box and forceloaded chunk
+# 1.16 Reminder Note : Setup yellow shulker box and forceloaded chunk
 
 execute unless score zauber_cauldrons gm4_modules matches 1 run data modify storage gm4:log queue append value {type:"install",module:"Zauber Cauldrons"}
 scoreboard players set zauber_cauldrons gm4_modules 1


### PR DESCRIPTION
-Adds spiral enchantment particle above a newly created Zauber Cauldron to indicate the "reading from the spellbook" lore. (Using local coordinate orbital modelling)
-Summons Vexes 1.5 blocks lower to where one would expect them to appear from bottles or cauldrons.
     -This allows them to pass through lingering clouds
-Adds a comment to init reminding about the required forceloaded chunk (Cause I thought things were broken for 20 mins :P)