### PR TITLE
CustomModelData stuff

### DIFF
--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/attack_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/attack_boost.mcfunction
@@ -2,7 +2,8 @@
 # at align xyz
 # run from recipe/armor/boots/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:feet,AttributeName:generic.attack_damage,Name:generic.attack_damage,Amount:0.35,Operation:2,UUID:[I;-728114158,242536513,454286749,553132649]},{Slot:feet,AttributeName:generic.armor,Name:generic.armor,Amount:2,Operation:0,UUID:[I;-746125590,665119254,-889993907,-451752547]},{Slot:feet,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;109577443,-525876610,218830453,-486302541]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:feet,AttributeName:generic.attack_damage,Name:generic.attack_damage,Amount:0.35,Operation:2,UUID:[I;-728114158,242536513,454286749,553132649]},{Slot:feet,AttributeName:generic.armor,Name:generic.armor,Amount:2,Operation:0,UUID:[I;-746125590,665119254,-889993907,-451752547]},{Slot:feet,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;109577443,-525876610,218830453,-486302541]}]}}}
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:3}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/health_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/health_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/boots/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:feet,AttributeName:generic.max_health,Name:generic.max_health,Amount:6,Operation:0,UUID:[I;173560930,227635867,-399895655,-974491959]},{Slot:feet,AttributeName:generic.armor,Name:generic.armor,Amount:2,Operation:0,UUID:[I;-575406329,423723369,-366761868,-724931900]},{Slot:feet,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;563222043,-576739570,-109925289,-896940653]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:feet,AttributeName:generic.max_health,Name:generic.max_health,Amount:6,Operation:0,UUID:[I;173560930,227635867,-399895655,-974491959]},{Slot:feet,AttributeName:generic.armor,Name:generic.armor,Amount:2,Operation:0,UUID:[I;-575406329,423723369,-366761868,-724931900]},{Slot:feet,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;563222043,-576739570,-109925289,-896940653]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:2}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/knockback_resistance.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/knockback_resistance.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/boots/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:feet,AttributeName:generic.knockback_resistance,Name:generic.knockback_resistance,Amount:0.25,Operation:0,UUID:[I;-244063540,-946724969,-502353081,-260690505]},{Slot:feet,AttributeName:generic.armor,Name:generic.armor,Amount:2,Operation:0,UUID:[I;-126556938,70564786,-378124159,518794193]},{Slot:feet,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;788661297,257142119,-985569927,-459662219]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:feet,AttributeName:generic.knockback_resistance,Name:generic.knockback_resistance,Amount:0.25,Operation:0,UUID:[I;-244063540,-946724969,-502353081,-260690505]},{Slot:feet,AttributeName:generic.armor,Name:generic.armor,Amount:2,Operation:0,UUID:[I;-126556938,70564786,-378124159,518794193]},{Slot:feet,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;788661297,257142119,-985569927,-459662219]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:5}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/speed_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/boots/speed_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/boots/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:feet,AttributeName:generic.movement_speed,Name:generic.movement_speed,Amount:0.12,Operation:2,UUID:[I;-381940460,932551270,-256402379,147935837]},{Slot:feet,AttributeName:generic.armor,Name:generic.armor,Amount:2,Operation:0,UUID:[I;-98045056,-801979198,171681426,-388316722]},{Slot:feet,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-108640928,-19939055,547652436,-796028868]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:feet,AttributeName:generic.movement_speed,Name:generic.movement_speed,Amount:0.12,Operation:2,UUID:[I;-381940460,932551270,-256402379,147935837]},{Slot:feet,AttributeName:generic.armor,Name:generic.armor,Amount:2,Operation:0,UUID:[I;-98045056,-801979198,171681426,-388316722]},{Slot:feet,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-108640928,-19939055,547652436,-796028868]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:4}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/attack_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/attack_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/chestplate/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:chest,AttributeName:generic.attack_damage,Name:generic.attack_damage,Amount:0.35,Operation:2,UUID:[I;727806222,89105198,496832575,-80857905]},{Slot:chest,AttributeName:generic.armor,Name:generic.armor,Amount:7,Operation:0,UUID:[I;-282257929,957982993,-774420762,275642819]},{Slot:chest,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;846339277,258910980,-725985973,273883983]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:chest,AttributeName:generic.attack_damage,Name:generic.attack_damage,Amount:0.35,Operation:2,UUID:[I;727806222,89105198,496832575,-80857905]},{Slot:chest,AttributeName:generic.armor,Name:generic.armor,Amount:7,Operation:0,UUID:[I;-282257929,957982993,-774420762,275642819]},{Slot:chest,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;846339277,258910980,-725985973,273883983]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:3}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/health_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/health_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/chestplate/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:chest,AttributeName:generic.max_health,Name:generic.max_health,Amount:6,Operation:0,UUID:[I;804844810,-704274940,-689241114,-123838463]},{Slot:chest,AttributeName:generic.armor,Name:generic.armor,Amount:7,Operation:0,UUID:[I;515425413,-436792323,149353304,-318737482]},{Slot:chest,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;880900701,-874259622,462764530,501152564]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:chest,AttributeName:generic.max_health,Name:generic.max_health,Amount:6,Operation:0,UUID:[I;804844810,-704274940,-689241114,-123838463]},{Slot:chest,AttributeName:generic.armor,Name:generic.armor,Amount:7,Operation:0,UUID:[I;515425413,-436792323,149353304,-318737482]},{Slot:chest,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;880900701,-874259622,462764530,501152564]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:2}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/knockback_resistance.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/knockback_resistance.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/chestplate/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:chest,AttributeName:generic.knockback_resistance,Name:generic.knockback_resistance,Amount:0.25,Operation:0,UUID:[I;-208702837,-587005396,359391026,562864091]},{Slot:chest,AttributeName:generic.armor,Name:generic.armor,Amount:7,Operation:0,UUID:[I;755839580,-164942903,120910349,576147854]},{Slot:chest,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-495088250,13265862,-401783722,-407879829]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:chest,AttributeName:generic.knockback_resistance,Name:generic.knockback_resistance,Amount:0.25,Operation:0,UUID:[I;-208702837,-587005396,359391026,562864091]},{Slot:chest,AttributeName:generic.armor,Name:generic.armor,Amount:7,Operation:0,UUID:[I;755839580,-164942903,120910349,576147854]},{Slot:chest,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-495088250,13265862,-401783722,-407879829]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:5}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/speed_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/chestplate/speed_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/chestplate/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:chest,AttributeName:generic.movement_speed,Name:generic.movement_speed,Amount:0.12,Operation:2,UUID:[I;645450573,-856361633,514004726,-599175145]},{Slot:chest,AttributeName:generic.armor,Name:generic.armor,Amount:7,Operation:0,UUID:[I;253405381,4486602,29451299,882170655]},{Slot:chest,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-451327934,-755693721,-327135901,-163799567]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:chest,AttributeName:generic.movement_speed,Name:generic.movement_speed,Amount:0.12,Operation:2,UUID:[I;645450573,-856361633,514004726,-599175145]},{Slot:chest,AttributeName:generic.armor,Name:generic.armor,Amount:7,Operation:0,UUID:[I;253405381,4486602,29451299,882170655]},{Slot:chest,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-451327934,-755693721,-327135901,-163799567]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:4}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/attack_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/attack_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/helmet/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:head,AttributeName:generic.attack_damage,Name:generic.attack_damage,Amount:0.35,Operation:2,UUID:[I;250004993,-600160793,-552771284,784442588]},{Slot:head,AttributeName:generic.armor,Name:generic.armor,Amount:3,Operation:0,UUID:[I;-440081014,-610623343,-606386611,689947835]},{Slot:head,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;807321613,318238802,-450100784,-475132420]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:head,AttributeName:generic.attack_damage,Name:generic.attack_damage,Amount:0.35,Operation:2,UUID:[I;250004993,-600160793,-552771284,784442588]},{Slot:head,AttributeName:generic.armor,Name:generic.armor,Amount:3,Operation:0,UUID:[I;-440081014,-610623343,-606386611,689947835]},{Slot:head,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;807321613,318238802,-450100784,-475132420]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:3}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/health_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/health_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/helmet/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:head,AttributeName:generic.max_health,Name:generic.max_health,Amount:6,Operation:0,UUID:[I;-603219768,-158339518,-706395048,79604255]},{Slot:head,AttributeName:generic.armor,Name:generic.armor,Amount:3,Operation:0,UUID:[I;-441595955,-453535841,-360996355,-301957561]},{Slot:head,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-57449288,-979610965,923369686,-139337251]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:head,AttributeName:generic.max_health,Name:generic.max_health,Amount:6,Operation:0,UUID:[I;-603219768,-158339518,-706395048,79604255]},{Slot:head,AttributeName:generic.armor,Name:generic.armor,Amount:3,Operation:0,UUID:[I;-441595955,-453535841,-360996355,-301957561]},{Slot:head,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-57449288,-979610965,923369686,-139337251]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:2}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/knockback_resistance.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/knockback_resistance.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/helmet/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:head,AttributeName:generic.knockback_resistance,Name:generic.knockback_resistance,Amount:0.25,Operation:0,UUID:[I;413901094,35727103,-998669247,923867442]},{Slot:head,AttributeName:generic.armor,Name:generic.armor,Amount:3,Operation:0,UUID:[I;483133475,389063065,-917720215,353703539]},{Slot:head,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;697609666,-622286711,-556181034,913816454]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:head,AttributeName:generic.knockback_resistance,Name:generic.knockback_resistance,Amount:0.25,Operation:0,UUID:[I;413901094,35727103,-998669247,923867442]},{Slot:head,AttributeName:generic.armor,Name:generic.armor,Amount:3,Operation:0,UUID:[I;483133475,389063065,-917720215,353703539]},{Slot:head,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;697609666,-622286711,-556181034,913816454]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:5}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/speed_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/helmet/speed_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/helmet/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:head,AttributeName:generic.movement_speed,Name:generic.movement_speed,Amount:0.12,Operation:2,UUID:[I;926064265,549727827,840778481,-94658344]},{Slot:head,AttributeName:generic.armor,Name:generic.armor,Amount:3,Operation:0,UUID:[I;204551258,685042583,911123345,430218417]},{Slot:head,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-26438964,-233002114,-533939998,-936212748]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:head,AttributeName:generic.movement_speed,Name:generic.movement_speed,Amount:0.12,Operation:2,UUID:[I;926064265,549727827,840778481,-94658344]},{Slot:head,AttributeName:generic.armor,Name:generic.armor,Amount:3,Operation:0,UUID:[I;204551258,685042583,911123345,430218417]},{Slot:head,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-26438964,-233002114,-533939998,-936212748]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:4}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/attack_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/attack_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/leggings/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:legs,AttributeName:generic.attack_damage,Name:generic.attack_damage,Amount:0.35,Operation:2,UUID:[I;98171848,952916658,399512331,-132029736]},{Slot:legs,AttributeName:generic.armor,Name:generic.armor,Amount:5,Operation:0,UUID:[I;82057528,-946070226,-866864687,-661686259]},{Slot:legs,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-662641133,529863347,171046543,-775356714]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:legs,AttributeName:generic.attack_damage,Name:generic.attack_damage,Amount:0.35,Operation:2,UUID:[I;98171848,952916658,399512331,-132029736]},{Slot:legs,AttributeName:generic.armor,Name:generic.armor,Amount:5,Operation:0,UUID:[I;82057528,-946070226,-866864687,-661686259]},{Slot:legs,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-662641133,529863347,171046543,-775356714]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:3}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/health_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/health_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/leggings/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:legs,AttributeName:generic.max_health,Name:generic.max_health,Amount:6,Operation:0,UUID:[I;-591878888,-240720226,-454922104,483042932]},{Slot:legs,AttributeName:generic.armor,Name:generic.armor,Amount:5,Operation:0,UUID:[I;489119544,-265654359,666574937,-45893978]},{Slot:legs,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-446547269,260741696,881610904,-421210777]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:legs,AttributeName:generic.max_health,Name:generic.max_health,Amount:6,Operation:0,UUID:[I;-591878888,-240720226,-454922104,483042932]},{Slot:legs,AttributeName:generic.armor,Name:generic.armor,Amount:5,Operation:0,UUID:[I;489119544,-265654359,666574937,-45893978]},{Slot:legs,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-446547269,260741696,881610904,-421210777]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:2}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/knockback_resistance.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/knockback_resistance.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/leggings/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:legs,AttributeName:generic.knockback_resistance,Name:generic.knockback_resistance,Amount:0.25,Operation:0,UUID:[I;773912078,704402546,202619636,954471299]},{Slot:legs,AttributeName:generic.armor,Name:generic.armor,Amount:5,Operation:0,UUID:[I;782007122,-25028284,588185585,-107321181]},{Slot:legs,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;948504386,107979224,-95861344,-432571820]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:legs,AttributeName:generic.knockback_resistance,Name:generic.knockback_resistance,Amount:0.25,Operation:0,UUID:[I;773912078,704402546,202619636,954471299]},{Slot:legs,AttributeName:generic.armor,Name:generic.armor,Amount:5,Operation:0,UUID:[I;782007122,-25028284,588185585,-107321181]},{Slot:legs,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;948504386,107979224,-95861344,-432571820]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:5}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1

--- a/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/speed_boost.mcfunction
+++ b/gm4_zauber_cauldrons/data/gm4_zauber_cauldrons/functions/recipes/armor/leggings/speed_boost.mcfunction
@@ -2,8 +2,9 @@
 # at align xyz
 # run from recipe/armor/leggings/apply_modifier.mcfunction
 
-data merge entity @s {CustomModelData:2,PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:legs,AttributeName:generic.movement_speed,Name:generic.movement_speed,Amount:0.12,Operation:2,UUID:[I;369107686,-99614761,-131788144,674642697]},{Slot:legs,AttributeName:generic.armor,Name:generic.armor,Amount:5,Operation:0,UUID:[I;244610376,-831197184,-527677447,406891107]},{Slot:legs,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-628832675,284114768,-748438237,705180656]}]}}}
+data merge entity @s {PickupDelay:0,Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"},AttributeModifiers:[{Slot:legs,AttributeName:generic.movement_speed,Name:generic.movement_speed,Amount:0.12,Operation:2,UUID:[I;369107686,-99614761,-131788144,674642697]},{Slot:legs,AttributeName:generic.armor,Name:generic.armor,Amount:5,Operation:0,UUID:[I;244610376,-831197184,-527677447,406891107]},{Slot:legs,AttributeName:generic.armor_toughness,Name:generic.armor_toughness,Amount:3,Operation:0,UUID:[I;-628832675,284114768,-748438237,705180656]}]}}}
 data modify entity @s Item.tag.display.Lore append value '{"translate":"%1$s%3427655$s","with":["+25% Magic",{"translate":"item.gm4.zauber_armour.magic","with":["25"]}],"color":"blue","italic":"false"}'
+execute unless data entity @s Item.tag.CustomModelData run data merge entity @s {Item:{tag:{CustomModelData:4}}}
 
 kill @e[type=item,dx=0,dy=0,dz=0,nbt=!{Item:{tag:{gm4_zauber_cauldrons:{item:"zauber_armor"}}}}]
 scoreboard players set recipe_success gm4_zc_data 1


### PR DESCRIPTION
(pulling to the right fork)

This makes it so that armor pieces get individual CustomModelData depending on what effect you're applying to them, and only if they don't already have CustomModelData (from Shamirs or SCUBA Tanks/Waders).

Attack = 3
Health = 2
Knockback = 5
Speed = 4

This allows for creation of Zauber Armour without CustomModelData by first applying a shamir to the piece and then removing it after making the piece zauber. Not sure if this is something that can be left alone or be fixed with a command on a clock when the item is dropped (something similar is already on the server).